### PR TITLE
Implemented a new Observable to emit when a user has been created.

### DIFF
--- a/projects/ngx-freshchat-lib/src/lib/ngx-freshchat-lib.service.ts
+++ b/projects/ngx-freshchat-lib/src/lib/ngx-freshchat-lib.service.ts
@@ -36,6 +36,23 @@ export class NgxFreshChatService {
     });
   }
 
+  /**
+   * Used to capture the user creation event. This can be used to save the restoreID.
+   * @returns An Observable which emits when a user is created.
+   * @author Will Poulson
+   */
+  onUserCreate(): Observable<any> {
+    return new Observable((observer) => {
+      this.getWidget().on('user:created', (res) => {
+        if (res.status !== 200) {
+          observer.error(res.status);
+        } else {
+          observer.next(res.data || null);
+        }
+      });
+    });
+  }
+
   getUser(): Observable<any> {
     return Observable.create( observer => {
       this.getWidget().user.get(


### PR DESCRIPTION
There was missing functionality to subscribe to user creation events.

Would also assist in this issue: #2 
As the solution for me to get the restore ID was to subscribe to the user creation event after initializing the widget.

Accepting this pull request would clean up my project code quite a bit. 